### PR TITLE
Created DiscType factory

### DIFF
--- a/models/DiscTypeFactory.js
+++ b/models/DiscTypeFactory.js
@@ -1,0 +1,94 @@
+module.exports = Object.assign({}, {
+    create: () => {
+        const makeModel = fakeMakeModel();
+        const weight = fakeWeight();
+
+        // const disc = new DiscType();
+        // disc.data = {
+        //     make: makeModel.make,
+        //     model: makeModel.model,
+        //     weight: weight,
+        // };
+        //
+        // return disc;
+
+        return {
+            make: makeModel.make,
+            model: makeModel.model,
+            weight: weight,
+        };
+    },
+});
+
+const arrayRand = (arr) => {
+    return arr[Math.floor(Math.random() * arr.length)]
+};
+
+const makesModels = [
+    {
+        make: 'DiscMania',
+        models: [
+            'CD Craze',
+            'CD3',
+            'DD Hysteria',
+            'PD Freak',
+        ],
+    },
+    {
+        make: 'Discraft',
+        models: [
+            'Avenger',
+            'Crush',
+            'Nuke',
+        ],
+    },
+    {
+        make: 'Innova',
+        models: [
+            'Archon',
+            'Beast',
+            'Katana',
+        ],
+    },
+    {
+        make: 'Prodigy',
+        models: [
+            'D1',
+            'D2',
+            'D3',
+        ],
+    },
+    {
+        make: 'Vibram',
+        models: [
+            'Lace',
+            'Solace',
+            'UnLace',
+        ],
+    },
+    {
+        make: 'Westside',
+        models: [
+            'Catapult',
+            'Destiny',
+            'Fortress',
+        ],
+    },
+];
+
+const fakeMakeModel = () => {
+    const makeModel = arrayRand(makesModels);
+    const model = arrayRand(makeModel.models);
+
+    return {
+        make: makeModel.make,
+        model: model,
+    };
+};
+
+const fakeWeight = () => {
+    const min = 100; // grams
+    const max = 200; // grams
+
+    return Math.round((Math.random() * (max - min)) + min);
+};

--- a/scripts/createDiscs.js
+++ b/scripts/createDiscs.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+require('node-env-file')(`${__dirname}/../.env`);
+
+const Mongo = require('../dal/Mongo.js');
+const DiscTypeFactory = require('../models/DiscTypeFactory');
+const MyObject = require('../lib/MyObject');
+
+const usage = "Usage: node createDiscs.js [numberOfDiscs]";
+const quantity = process.argv[2];
+
+const validate = (quantity) => {
+    if (isNaN(quantity)) {
+        throw usage;
+    }
+
+    return null;
+};
+
+const createOneDisc = () => {
+    return DiscTypeFactory.create();
+    // disc._store();
+};
+
+const createDiscs = (db) => {
+    let discs = [];
+    for (let i = quantity; i > 0; i--) {
+        discs.push(createOneDisc());
+    }
+
+    db.collection('DiscTypes').insertMany(discs, function (err, result) {
+        console.log(`Inserted ${quantity} documents into the DiscTypes collection.`);
+        db.close();
+    });
+};
+
+MyObject.P(validate, [quantity])
+        .then(Mongo.Client.connect(process.env.MONGODB, (err, db) => {
+            createDiscs(db);
+        }))
+        .catch(e => {
+            console.error(e.stack || e);
+            process.exit(1)
+        });


### PR DESCRIPTION
Mock DiscTypes can be bulk-inserted into the MongoDb by using the `scripts/createDiscs.js` script from the command line.